### PR TITLE
fixed batch variable or latent variable attribute checking

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -44,8 +44,8 @@ make_cell_attr <- function(umi, cell_attr, latent_var, batch_var, latent_var_non
   # problems later on
   rel_attr <- cell_attr[, c(latent_var, batch_var, latent_var_nonreg)]
   if (any(is.na(rel_attr)) || 
-      any(is.nan(rel_attr)) || 
-      any(is.infinite(rel_attr))) {
+      any(is.nan(unlist(rel_attr, use.names = FALSE))) || 
+      any(is.infinite(unlist(rel_attr, use.names = FALSE)))) {
     stop('cell attributes cannot contain any NA, NaN, or infinite values')
   }
   


### PR DESCRIPTION
If SCTransform is used with a batch or latent variable, it confirms that there are no missing values in the requested variable. However, it calls `is.nan` and `is.infinite` on a list which is not allowed. This error only appears when calling SCTransform with a batch or latent variable, otherwise this step is skipped. This is a fix for issue #88 